### PR TITLE
BIDS Data curation

### DIFF
--- a/convert_to_BIDS.py
+++ b/convert_to_BIDS.py
@@ -1,6 +1,11 @@
 # This script serves to reorganize the data from /usr/Spinal_Cord_Data/Tumor into BIDS dataset
-# located under /usr/Spinal_Cord_Data/Tumor_BIDS
+# located under /usr/Spinal_Cord_Data/Tumor_BIDS .
+#
+#  The script merges together the "BIDS" datasets Astrocytoma_144_BIDS, Ependymoma_393_BIDS, Hemandioblastoma_264_BIDS 
+# into a single BIDS dataset.
+#
 # To use simply call python BIDS_data_china -d /usr/Spinal_Cord_Data/Tumor
+#
 # Created by: Alexandru Foias 
 
 import os,shutil,re,json,csv,argparse
@@ -36,6 +41,9 @@ def main(path_data):
                 '_T1w.nii.gz':('_T1w.nii.gz',''),
                 '_T2w.nii.gz':('_T2w.nii.gz',''),
                 }
+    tumor_dict = {'Astr':'Astrocytoma',
+                  'Epen': 'Ependymoma',
+                  'Hema': 'Hemandioblastoma'}
     #Rearrange data into BIDS format
     for cwd, dirs, files in os.walk(rootDataPath):
         for file in files:
@@ -69,6 +77,10 @@ def main(path_data):
                 "age": {
                     "LongName": "Participant age",
                     "Description": "yy"
+                },
+                "tumor_type":{
+                    "LongName": "Tumor type",
+                    "Description": "yy"
                 }
                 }]
     # Save participants.json
@@ -94,12 +106,13 @@ def main(path_data):
             row_participants.append(dirs)
             row_participants.append('-')
             row_participants.append('-')
+            row_participants.append(tumor_dict[dirs.split('-')[1][0:4]])
             participants.append(row_participants)
             
     # # Save participants.tsv
     with open(participants_tsvFILENAME, 'w') as tsv_file:
         tsv_writer = csv.writer(tsv_file, delimiter='\t', lineterminator='\n')
-        tsv_writer.writerow(["participant_id", "sex", "age"])
+        tsv_writer.writerow(["participant_id", "sex", "age", "tumor_type"])
         for item in participants:
             tsv_writer.writerow(item)
     #Export sidecar json 

--- a/convert_to_BIDS.py
+++ b/convert_to_BIDS.py
@@ -1,31 +1,116 @@
-#
-#   Script to move tumor segmentation files to respect BIDS standards
-#
+# This script serves to reorganize the data from /usr/Spinal_Cord_Data/Tumor into BIDS dataset
+# located under /usr/Spinal_Cord_Data/Tumor_BIDS
+# To use simply call python BIDS_data_china -d /usr/Spinal_Cord_Data/Tumor
+# Created by: Alexandru Foias 
 
-import os
-import shutil
+import os,shutil,re,json,csv,argparse
 
-BIDS_PATHS = ['/usr/Spine_Cord_Data/Tumor/Astrocytoma_144_BIDS',
-              '/usr/Spine_Cord_Data/Tumor/Ependymoma_393_BIDS',
-              '/usr/Spine_Cord_Data/Tumor/Hemandioblastoma_264_BIDS']
+def get_parameters():
+    parser = argparse.ArgumentParser(description='This script is used for '
+                                     'aranging sct_large into BIDS compatible mode')
+    parser.add_argument("-d", "--data",
+                        help="Path to dataset directory",
+                        required=True)
+    args = parser.parse_args()
+    return args
 
-for BIDS_PATH in BIDS_PATHS:
-    NEW_LABELS_PATH = os.path.join(BIDS_PATH, 'derivatives', 'labels')
-    subjects = os.listdir(BIDS_PATH)
-    for subject in subjects:
-        # Only select subject folders
-        if 'sub' in subject:
-            NEW_SUBJECT_SEG_PATH = os.path.join(NEW_LABELS_PATH, subject, 'anat')
-            if not os.path.exists(NEW_SUBJECT_SEG_PATH):
-                # Create directory
-                os.makedirs(NEW_SUBJECT_SEG_PATH)
-            PATH_TO_SUBJECT = os.path.join(BIDS_PATH, subject, 'manual_label')
-            files = os.listdir(PATH_TO_SUBJECT)
-            for file in files:
-                PATH_TO_SEG = os.path.join(PATH_TO_SUBJECT, file)
-                NEW_PATH_TO_SEG = os.path.join(NEW_SUBJECT_SEG_PATH, file)
-                if os.path.exists(PATH_TO_SEG):
-                    # Move the tumor segmentation file
-                    shutil.move(PATH_TO_SEG, NEW_PATH_TO_SEG)
-            # Remove empty folder 'manual label'
-            os.rmdir(PATH_TO_SUBJECT)
+def main(path_data):
+    """
+    Main function
+    :param path_data:
+    :return:
+    """
+    #Define filenames & paths
+    rootDataPath = path_data
+    rootBIDSDataPath_init = '/'.join(rootDataPath.split('/')[0:-1])
+    rootBIDSDataPath = rootBIDSDataPath_init + '/' + rootDataPath.split('/')[-1] + '_BIDS'
+    dataset_description_jsonFILENAME = os.path.join(rootBIDSDataPath, 'dataset_description.json')
+    participants_jsonFILENAME = os.path.join(rootBIDSDataPath,'participants.json')
+    participants_tsvFILENAME = os.path.join(rootBIDSDataPath, 'participants.tsv')
+
+    if not os.path.isdir(rootBIDSDataPath):
+        os.mkdir(rootBIDSDataPath)
+
+    img_dict = {'_T1_manual_lesion_label.nii.gz':('_T1w_seg-tumor.nii.gz','derivatives/labels'),
+                '_T2_manual_lesion_label.nii.gz':('_T2w_seg-tumor.nii.gz','derivatives/labels'),
+                '_T1w.nii.gz':('_T1w.nii.gz',''),
+                '_T2w.nii.gz':('_T2w.nii.gz',''),
+                }
+    #Rearrange data into BIDS format
+    for cwd, dirs, files in os.walk(rootDataPath):
+        for file in files:
+            file_path = os.path.join(cwd,file)
+            
+            for img_key in img_dict.keys():
+                if file.endswith(img_key):
+                    sub_full = str(file.split('_')[0])
+                    sub_id = (re.findall('\d+', sub_full ))
+                    sub_type = cwd.split('/')[-3].split('_')[0][0:4]
+                    sub_id_new = "sub-"+ sub_type + sub_id[0]
+                    sub_new_folder = os.path.join(rootBIDSDataPath,img_dict[img_key][1],sub_id_new , "anat")
+                    if not os.path.exists(sub_new_folder):
+                        os.makedirs(sub_new_folder)
+                    new_file_path = os.path.join(sub_new_folder, sub_id_new + img_dict[img_key][0])
+                    print ("Initial path: " + file_path)
+                    print ("New path:     " + new_file_path + '\n')
+                    shutil.copy(file_path,new_file_path)
+
+    #Create participants.json
+    content_participants_json = [
+            {
+                "participant_id": {
+                    "LongName": "Participant ID",
+                    "Description": "Unique ID"
+                },
+                "sex": {
+                    "LongName": "Participant gender",
+                    "Description": "M or F"
+                },
+                "age": {
+                    "LongName": "Participant age",
+                    "Description": "yy"
+                }
+                }]
+    # Save participants.json
+    with open(participants_jsonFILENAME, 'w') as outfile:
+        outfile.write(json.dumps(content_participants_json[0], indent=2))
+        outfile.close()
+
+    #Create dataset_description.json
+    dataset_description = {}
+    dataset_description[u'Name'] = 'SCT_Tumor'
+    dataset_description[u'BIDSVersion'] = '1.2.1'
+
+    # Save dataset_description.json
+    with open(dataset_description_jsonFILENAME, 'w') as outfile:
+        outfile.write(json.dumps(dataset_description,
+                                    indent=2, sort_keys=True))
+        outfile.close()
+    participants =[]
+    #Create participants.tsv
+    for dirs in os.listdir(rootBIDSDataPath):
+        if dirs.startswith('sub-'):
+            row_participants = []
+            row_participants.append(dirs)
+            row_participants.append('-')
+            row_participants.append('-')
+            participants.append(row_participants)
+            
+    # # Save participants.tsv
+    with open(participants_tsvFILENAME, 'w') as tsv_file:
+        tsv_writer = csv.writer(tsv_file, delimiter='\t', lineterminator='\n')
+        tsv_writer.writerow(["participant_id", "sex", "age"])
+        for item in participants:
+            tsv_writer.writerow(item)
+    #Export sidecar json 
+    for cwd, dirs, files in os.walk(rootBIDSDataPath):
+        for file in files:
+            if file.endswith('.nii.gz'):
+                    currentFilePath = os.path.join(cwd + '/' + file)
+                    jsonAdjPath = os.path.join(cwd + '/' + file.split('.')[0]+'.json')
+                    if os.path.exists(os.path.join(cwd + '/' + file.split('.')[0]+'.json'))==False:
+                        print ('Warning - Missing: ' +  jsonAdjPath)
+                        os.system('touch ' + jsonAdjPath)
+if __name__ == "__main__":
+    args = get_parameters()
+    main(args.data)

--- a/convert_to_BIDS.py
+++ b/convert_to_BIDS.py
@@ -11,8 +11,8 @@
 import os,shutil,re,json,csv,argparse
 
 def get_parameters():
-    parser = argparse.ArgumentParser(description='This script is used for '
-                                     'aranging sct_large into BIDS compatible mode')
+    parser = argparse.ArgumentParser(description='This script is used to '
+                                     'arrange data under /usr/Spinal_Cord_Data/Tumor into BIDS compatible mode')
     parser.add_argument("-d", "--data",
                         help="Path to dataset directory",
                         required=True)


### PR DESCRIPTION
I decided to modify `convert_to_BIDS.py` because it didn't follow all the BIDS specifications.
The current version of the script merges together the "BIDS" datasets `Astrocytoma_144_BIDS, Ependymoma_393_BIDS, Hemandioblastoma_264_BIDS` into a single BIDS dataset.

The new dataset will be located under `/usr/Spinal_Cord_Data/Tumor_BIDS`. Every subject will have a name similar to `sub-AstrXXX` or `sub-EpenXXX` or `sub-HemaXXX`. The old subject numbers were kept for convenience.

p.s. I don't have write access, that's why I created a fork.